### PR TITLE
Link QHacks logos to static site

### DIFF
--- a/packages/client/components/Login/Login.js
+++ b/packages/client/components/Login/Login.js
@@ -37,8 +37,8 @@ getRedirectPath() {
 		return (
 			<div className="login-form-wrapper">
 				<a href="http://qhacks.io">
-				<img src={require('../../assets/img/qhacks-tricolor-logo.svg')}
-						className="qhacks-logo-login"/>
+					<img src={require('../../assets/img/qhacks-tricolor-logo.svg')}
+							className="qhacks-logo-login"/>
 				</a>
 				<LoginForm onSubmit={this.handleLogin.bind(this)}
 									applicationsStatus={applicationsStatus}

--- a/packages/client/components/Login/Login.js
+++ b/packages/client/components/Login/Login.js
@@ -36,8 +36,10 @@ getRedirectPath() {
 		const { applicationsStatus, loginLoading, loginError } = this.props;
 		return (
 			<div className="login-form-wrapper">
+				<a href="http://qhacks.io">
 				<img src={require('../../assets/img/qhacks-tricolor-logo.svg')}
 						className="qhacks-logo-login"/>
+				</a>
 				<LoginForm onSubmit={this.handleLogin.bind(this)}
 									applicationsStatus={applicationsStatus}
 									loginLoading={loginLoading}
@@ -61,7 +63,7 @@ getRedirectPath() {
 										className="fontWeight-lighter"
 										inverted
 										size="medium">
-							QHacks 2018, Queen's University
+							QHacks 2018, Queen&apos;s University
 						</Header>
 					</div>
 				</div>

--- a/packages/client/components/MenuBar/MenuBar.js
+++ b/packages/client/components/MenuBar/MenuBar.js
@@ -33,7 +33,7 @@ class MenuBar extends Component {
 	renderLeftSideMenu() {
 		return (
 			<Menu.Menu position="left">
-				<Menu.Item as={Link} to="/">
+				<Menu.Item as={Link} to="http://qhacks.io/">
 					{this.renderQHacksCrown()}
 				</Menu.Item>
 				<Menu.Item as={Link} to="/">


### PR DESCRIPTION
## Proposed Change

Fixes Issue Ticket: #67 

### Description

Links the logos in the login page and hacker dashboard menu bar to http://qhacks.io instead of dashboard root.

## Pull Request Checklist:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally prior to submission?
<!--N/A: 3. [ ] Have you written new tests for your core changes, as applicable?-->
