### PR TITLE
Update refresh token logic

### DIFF
--- a/packages/server/auth/index.js
+++ b/packages/server/auth/index.js
@@ -23,7 +23,7 @@ module.exports = () => (req, res, next) => {
   }
 
   jwt.verify(token, AUTH_SECRET, (err, decoded) => {
-    if (err) {
+    if (err || decoded.type === "refresh") {
       const error = createError(
         ERROR_TEMPLATES.UNAUTHORIZED,
         ERROR.INVALID_TOKEN,


### PR DESCRIPTION
## Proposed Change

Fixes: #115

Added in a type to the access token and added a check for type in auth middleware.

### How you did this?
Updated a line of code in the `auth` middleware so that it fails not only if there is an error, but also if the token used is a refresh token and not an access token.

### Why are you choosing this approach?
I originally chose the approach of adding a `type: access` to the access jwt, however this was unnecessary so I chose this approach to make as little changes to the codebase as possible.

### Any open questions you want to ask code reviewers?
Nope
### List of changes:

  - Added type to access token
  - Checked for type in auth middleware

## Pull Request Checklist:

  - [x] My submission passes all tests.
  - [x] I have lint my code locally prior to submission.
  - [ ] I have written new tests for my core changes (where applicable). **!!SOON!!**
  - [x] I have referenced all useful information (issues, tasks, etc) in the pull request.
