### PR TITLE
Remove dev deploy job cd job for now

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,12 +50,6 @@ jobs:
 
 workflows:
   version: 2
-  deploy:
+  run-tests:
     jobs:
       - code-style
-      - dev-deploy:
-          requires:
-            - code-style
-          filters:
-            branches:
-              only: /^(dev|release/.+)$/


### PR DESCRIPTION
## Proposed Change

We are currently not using the live versions of the application, as a result we don't need to run the deploy CD job on merges. It will always fail while the servers are turned off, I like to see green and not red, so for now lets remove it and add it back when appropriate.

### How you did this?

Remove the `dev-deploy` job from running in our workflows.

### Why are you choosing this approach?

No reason to have this run to always fail while our servers are turned off.

### Any open questions you want to ask code reviewers?

Nope! 😄 

### List of changes:

  - Removes unused `dev-deploy` job from running in CI/CD.

## Pull Request Checklist:

  - [x] My submission passes all tests.
  - [x] I have lint my code locally prior to submission.
  - [x] I have written new tests for my core changes (where applicable).
  - [x] I have referenced all useful information (issues, tasks, etc) in the pull request.

