### PR TITLE
Nohoist semantic-ui to reduce coupling

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,11 @@
   "packages": [
     "packages/*"
   ],
-  "version": "1.3.4"
+  "version": "1.3.4",
+  "command": {
+    "bootstrap": {
+      "hoist": "**",
+      "nohoist": "semantic-ui-*"
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "url": "https://github.com/qhacks/hacker-dashboard.git"
   },
   "scripts": {
-    "bootstrap": "npm install --unsafe-perm || ((if [ -f npm-debug.log ]; then cat npm-debug.log; fi) && false) && lerna bootstrap --hoist",
+    "bootstrap": "npm install --unsafe-perm || ((if [ -f npm-debug.log ]; then cat npm-debug.log; fi) && false) && lerna bootstrap",
     "build": "lerna run build --stream",
     "dev": "lerna run build --scope email && lerna run dev --scope server --scope client --stream --parallel",
     "start": "lerna run start --scope server --stream",

--- a/packages/client/assets/semantic-ui/theme.config
+++ b/packages/client/assets/semantic-ui/theme.config
@@ -80,7 +80,7 @@
 @themesFolder : 'themes';
 
 /* Path to site override folder */
-@siteFolder  : '../../packages/client/assets/semantic-ui/site';
+@siteFolder  : '../../assets/semantic-ui/site';
 
 /*******************************
          Import Theme


### PR DESCRIPTION
## Proposed Change

In the lerna config we opt not to hoist semantic ui so our overrides don't have to dig out to the root of the repo, this change makes the client less coupled to the repo.

### How you did this?

Opt not to hoist semantic-ui in lerna config.

### Why are you choosing this approach?

Reduces coupling! 😄 

### Any open questions you want to ask code reviewers?

Nope!

### List of changes:

  - Opt not to hoist semantic-ui in lerna config.

## Pull Request Checklist:

  - [x] My submission passes all tests.
  - [x] I have lint my code locally prior to submission.
  - [ ] I have written new tests for my core changes (where applicable).
  - [x] I have referenced all useful information (issues, tasks, etc) in the pull request.

