### PR TITLE
Fix typo in accepted and waitlist email templates

### DIFF
--- a/packages/email/templates/application-successful.mjml
+++ b/packages/email/templates/application-successful.mjml
@@ -20,7 +20,7 @@
     <mj-section background-color="white" border-bottom="10px solid #f5f5f5" padding="40px 0">
       <mj-column width="600px">
         <mj-text font-weight="bold" font-size="42px" line-height="48px" align="center" padding="0px">Welcome to QHacks!</mj-text>
-        <mj-text font-size="18px" line-height="28px" padding="15px 30px" align="center" color="#383838">QHacks is more than a hackathon. It's a community of creators and innovators, andwe're so happy to have you. Welcome! Now that you've applied to attend QHacks 2018, you probably have some questions. Good news, we're here to answer them.</mj-text>
+        <mj-text font-size="18px" line-height="28px" padding="15px 30px" align="center" color="#383838">QHacks is more than a hackathon. It's a community of creators and innovators, and we're so happy to have you. Welcome! Now that you've applied to attend QHacks 2018, you probably have some questions. Good news, we're here to answer them.</mj-text>
       </mj-column>
     </mj-section>
     <mj-raw>

--- a/packages/email/templates/application-waitlisted.mjml
+++ b/packages/email/templates/application-waitlisted.mjml
@@ -20,7 +20,7 @@
     <mj-section background-color="white" border-bottom="10px solid #f5f5f5" padding="40px 0">
       <mj-column width="600px">
         <mj-text font-weight="bold" font-size="42px" line-height="48px" align="center" padding="0px">Welcome to QHacks!</mj-text>
-        <mj-text font-size="18px" line-height="28px" padding="15px 30px" align="center" color="#383838">QHacks is more than a hackathon. It's a community of creators and innovators, andwe're so happy to have you. Welcome! Now that you've applied to attend QHacks 2018, you probably have some questions. Good news, we're here to answer them.</mj-text>
+        <mj-text font-size="18px" line-height="28px" padding="15px 30px" align="center" color="#383838">QHacks is more than a hackathon. It's a community of creators and innovators, and we're so happy to have you. Welcome! Now that you've applied to attend QHacks 2018, you probably have some questions. Good news, we're here to answer them.</mj-text>
       </mj-column>
     </mj-section>
     <mj-raw>


### PR DESCRIPTION
## Proposed Change
- Noticed a small typo in the email sent out from the hacker dashboard when running locally. Fixed it 👀✏️📝✅  
Fixes:
- Corrected a small typo (`andwe're` => `and we're`)
### How you did this?
- Updated the `.mjml` files
### Why are you choosing this approach?
- Will ensure that our emails are typo free in the future 👍
### Any open questions you want to ask code reviewers?
- No
### List of changes:
  - A small typo in the email templates

## Pull Request Checklist:

  - [X] My submission passes all tests.
  - [X] I have lint my code locally prior to submission.
  - [ ] I have written new tests for my core changes (where applicable).
  - [X] I have referenced all useful information (issues, tasks, etc) in the pull request.

